### PR TITLE
fix default value for driftfile on Suse

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,7 +119,7 @@ class ntp (
       $default_step_tickers_ensure = 'absent'
       $default_service_name        = 'ntp'
       $default_config_file         = '/etc/ntp.conf'
-      $default_driftfile           = '/var/lib/ntp/ntp.drift'
+      $default_driftfile           = '/var/lib/ntp/drift/ntp.drift'
       $default_keys                = undef
 
       case $::lsbmajdistrelease {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -497,7 +497,7 @@ describe 'ntp' do
           })
         }
 
-        it { should contain_file('ntp_conf').with_content(/driftfile \/var\/lib\/ntp\/ntp.drift/) }
+        it { should contain_file('ntp_conf').with_content(/driftfile \/var\/lib\/ntp\/drift\/ntp.drift/) }
         it { should contain_file('ntp_conf').with_content(/# Statistics are not being logged/) }
         it { should contain_file('ntp_conf').with_content(/server 0.us.pool.ntp.org\nserver 1.us.pool.ntp.org\nserver 2.us.pool.ntp.org/) }
         it { should_not contain_file('ntp_conf').with_content(/^keys \/etc\/ntp\/keys$/) }
@@ -551,7 +551,7 @@ describe 'ntp' do
           })
         }
 
-        it { should contain_file('ntp_conf').with_content(/driftfile \/var\/lib\/ntp\/ntp.drift/) }
+        it { should contain_file('ntp_conf').with_content(/driftfile \/var\/lib\/ntp\/drift\/ntp.drift/) }
         it { should contain_file('ntp_conf').with_content(/# Statistics are not being logged/) }
         it { should contain_file('ntp_conf').with_content(/server 0.us.pool.ntp.org\nserver 1.us.pool.ntp.org\nserver 2.us.pool.ntp.org/) }
         it { should_not contain_file('ntp_conf').with_content(/^keys \/etc\/ntp\/keys$/) }


### PR DESCRIPTION
/var/lib/ntp/ is owned by root and therefore ntp can't write there on Suse.
/var/lib/ntp/drift/ is writeable to ntp.
