### PR TITLE
Manage sysconfig file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ ntp.conf's mode
 
 - *Default*: 0644
 
+sysconfig_path
+--------------
+Path to the ntp sysconfig config file.
+
+- *Default*: 'USE_DEFAULTS'
+
+sysconfig_options
+-----------------
+String with startup options to pass to ntp.
+
+- *Default*: 'USE_DEFAULTS'
+
 step_tickers_ensure
 -------------------
 Ensure step tickers file. Valid values are 'present' and 'absent'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@ class ntp (
   $logfile             = 'UNSET',
   $ignore_local_clock  = false,
   $disable_monitor     = false,
+  $sysconfig_path      = 'USE_DEFAULTS',
+  $sysconfig_options   = 'USE_DEFAULTS',
 ) {
 
   # validate type as array or fail
@@ -139,6 +141,9 @@ class ntp (
       $default_driftfile           = '/var/lib/ntp/ntp.drift'
       $default_keys                = '/etc/ntp/keys'
       $default_enable_tinker       = true
+      $default_sysconfig_path      = '/etc/default/ntp'
+      $sysconfig_erb               = 'sysconfig.debian.erb'
+      $default_sysconfig_options   = '-g'
     }
     'RedHat': {
       $default_package_name        = [ 'ntp' ]
@@ -152,11 +157,28 @@ class ntp (
       $default_config_file         = '/etc/ntp.conf'
       $default_keys                = '/etc/ntp/keys'
       $default_enable_tinker       = true
-      if $::operatingsystemmajrelease == '7' or $::lsbmajdistrelease == '7' {
-        $default_driftfile           = '/var/lib/ntp/drift'
-      } else {
-        $default_driftfile           = '/var/lib/ntp/ntp.drift'
+      $default_sysconfig_path      = '/etc/sysconfig/ntpd'
+      case $::operatingsystemrelease {
+        /^5/: {
+          $default_driftfile           = '/var/lib/ntp/ntp.drift'
+          $sysconfig_erb               = 'sysconfig.rhel5.erb'
+          $default_sysconfig_options   = '-u ntp:ntp -p /var/run/ntpd.pid'
+        }
+        /^6/: {
+          $default_driftfile           = '/var/lib/ntp/ntp.drift'
+          $sysconfig_erb               = 'sysconfig.rhel6.erb'
+          $default_sysconfig_options   = '-u ntp:ntp -p /var/run/ntpd.pid -g'
+        }
+        /^7/: {
+          $default_driftfile           = '/var/lib/ntp/drift'
+          $sysconfig_erb               = 'sysconfig.rhel7.erb'
+          $default_sysconfig_options   = '-g'
+        }
+        default: {
+          fail("The ntp module supports RedHat like systems with major releases 5, 6, and 7 and you have ${::operatingsystemrelease}")
+        }
       }
+
     }
     'Suse': {
       $default_package_noop        = false
@@ -169,18 +191,31 @@ class ntp (
       $default_driftfile           = '/var/lib/ntp/drift/ntp.drift'
       $default_keys                = undef
       $default_enable_tinker       = true
+      $default_sysconfig_path      = '/etc/sysconfig/ntp'
 
-      case $::lsbmajdistrelease {
-        '9','10': {
-          $default_package_name     = [ 'xntp' ]
-          $default_service_name     = 'ntp'
+      case $::operatingsystemrelease {
+        /^9/: {
+          $default_package_name       = [ 'xntp' ]
+          $default_service_name       = 'ntp'
+          $default_sysconfig_options  = '-u ntp'
+          $sysconfig_erb              = 'sysconfig.suse9.erb'
         }
-        '11': {
-          $default_package_name     = [ 'ntp' ]
-          $default_service_name     = 'ntp'
+        /^10/: {
+          $default_package_name       = [ 'xntp' ]
+          $default_service_name       = 'ntp'
+          $default_sysconfig_options  = '-u ntp'
+          $sysconfig_erb              = 'sysconfig.suse10.erb'
         }
-        '12': {
-          $default_package_name     = [ 'ntp' ]
+        /^11/: {
+          $default_package_name       = [ 'ntp' ]
+          $default_service_name       = 'ntp'
+          $default_sysconfig_options  = '-g -u ntp:ntp'
+          $sysconfig_erb              = 'sysconfig.suse11.erb'
+        }
+        /^12/: {
+          $default_package_name       = [ 'ntp' ]
+          $default_sysconfig_options  = '-g -u ntp:ntp'
+          $sysconfig_erb              = 'sysconfig.suse12.erb'
           if $::operatingsystem == 'OpenSuSE' {
             $default_service_name = 'ntp'
           } else {
@@ -188,7 +223,7 @@ class ntp (
           }
         }
         default: {
-          fail("The ntp module is supported by release 9, 10, 11 and 12 of the Suse OS Family. Your release is ${::lsbmajdistrelease}")
+          fail("The ntp module supports Suse like systems with major releases 9, 10, 11, and 12 and you have ${::operatingsystemrelease}")
         }
       }
     }
@@ -328,6 +363,18 @@ class ntp (
     fail('restrict_localhost must be an array or the string \'USE_DEFAULTS\'.')
   }
 
+  if $sysconfig_path == 'USE_DEFAULTS' {
+    $sysconfig_path_real = $default_sysconfig_path
+  } else {
+    $sysconfig_path_real = $sysconfig_path
+  }
+
+  if $sysconfig_options == 'USE_DEFAULTS' {
+    $sysconfig_options_real = $default_sysconfig_options
+  } else {
+    $sysconfig_options_real = $sysconfig_options
+  }
+
   if ($package_adminfile_real != '') and ($package_adminfile_real != undef) {
 
     file { 'admin_file':
@@ -346,6 +393,19 @@ class ntp (
     source    => $package_source_real,
     adminfile => $package_adminfile_real,
     before    => File['ntp_conf'],
+  }
+
+  if $::kernel == 'Linux' {
+    file { 'ntp_sysconfig':
+      ensure  => file,
+      path    => $sysconfig_path_real,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template("ntp/${ntp::sysconfig_erb}"),
+      notify  => Service['ntp_service'],
+      require => Package[$package_name_real],
+    }
   }
 
   file { 'ntp_conf':

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -294,11 +294,11 @@ describe 'ntp' do
           end
         else
           let :facts do
-            { :osfamily          => v[:osfamily],
-              :operatingsystem   => v[:operatingsystem],
-              :lsbmajdistrelease => v[:release],
-              :kernel            => v[:kernel],
-              :virtual           => v[:virtual],
+            { :osfamily               => v[:osfamily],
+              :operatingsystem        => v[:operatingsystem],
+              :operatingsystemrelease => v[:release],
+              :kernel                 => v[:kernel],
+              :virtual                => v[:virtual],
             }
           end
         end
@@ -436,7 +436,12 @@ describe 'ntp' do
   end
 
   describe 'with driftfile set to' do
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     [ '', '/var/lib/ntp/ntp.drift','/etc/ntp/drift'].each do |value|
       context "valid #{value} as #{value.class}" do
@@ -464,7 +469,12 @@ describe 'ntp' do
   end
 
   describe 'with enable_stats' do
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     ['true',true].each do |value|
       context "specified as #{value}" do
@@ -483,7 +493,12 @@ describe 'ntp' do
     end
 
     context 'as an invalid type (non-boolean)' do
-      let(:facts) { { :osfamily => 'RedHat' } }
+      let :facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '6.0',
+        }
+      end
       let(:params) { { :enable_stats => ['not','a','boolean'] } }
 
       it do
@@ -495,9 +510,16 @@ describe 'ntp' do
   end
 
   describe 'with statsdir' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
+
     context 'specified as a valid path' do
       context 'with enable_stats as true' do
-        let(:facts) { { :osfamily => 'RedHat' } }
+
         let(:params) do
           {
             :enable_stats => true,
@@ -509,7 +531,6 @@ describe 'ntp' do
       end
 
       context 'with enable_stats as false' do
-        let(:facts) { { :osfamily => 'RedHat' } }
         let(:params) do
           {
             :enable_stats => false,
@@ -522,7 +543,6 @@ describe 'ntp' do
     end
 
     context 'specified as an invalid path' do
-      let(:facts) { { :osfamily => 'RedHat' } }
       let(:params) { { :statsdir => 'invalid/path' } }
 
       it do
@@ -534,7 +554,12 @@ describe 'ntp' do
   end
 
   describe 'with keys set to' do
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     [ '', '/var/lib/ntp/keys','/etc/ntp/keysfile'].each do |value|
       context "valid #{value} as #{value.class}" do
@@ -562,7 +587,12 @@ describe 'ntp' do
   end
 
   describe 'with peers param set' do
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     context 'to a hash' do
       let(:params) { { :peers => peers } }
@@ -661,7 +691,7 @@ describe 'ntp' do
     it do
       expect {
         should contain_class('ntp')
-      }.to raise_error(Puppet::Error,/The ntp module is supported by release 9, 10, 11 and 12 of the Suse OS Family./)
+      }.to raise_error(Puppet::Error,/The ntp module supports Suse like systems with major releases 9, 10, 11, and 12 and you have./)
     end
   end
 
@@ -687,7 +717,12 @@ describe 'ntp' do
 
   context 'with invalid value for step_tickers_ensure param' do
     let(:params) { { :step_tickers_ensure => 'invalid' } }
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     it do
       expect {
@@ -698,7 +733,12 @@ describe 'ntp' do
 
   context 'with invalid path for step_tickers_path param' do
     let(:params) { { :step_tickers_path => 'invalid/path' } }
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     it do
       expect {
@@ -710,7 +750,12 @@ describe 'ntp' do
   [true,'true'].each do |value|
     context "with ignore_local_clock set to #{value}" do
       let(:params) { { :ignore_local_clock => value } }
-      let(:facts) { { :osfamily => 'RedHat' } }
+      let :facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '6.0',
+        }
+      end
 
       it { should contain_file('ntp_conf').without_content(/^server\s+127.127.1.0/) }
       it { should contain_file('ntp_conf').without_content(/^fudge\s+127.127.1.0 stratum 10/) }
@@ -719,7 +764,12 @@ describe 'ntp' do
 
   context 'with invalid ignore_local_clock 1' do
     let(:params) { { :ignore_local_clock => ['bad','input'] } }
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     it do
       expect {
@@ -730,7 +780,12 @@ describe 'ntp' do
 
   context 'with invalid ignore_local_clock 2' do
     let(:params) { { :ignore_local_clock => 'nottrue' } }
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     it do
       expect {
@@ -741,9 +796,10 @@ describe 'ntp' do
 
   context 'on Linux physical machine' do
     let :facts do
-      { :osfamily => 'RedHat',
-        :virtual  => 'physical',
-	      :kernel   => 'Linux'
+      { :osfamily               => 'RedHat',
+        :operatingsystemrelease =>  '6.0',
+        :virtual                => 'physical',
+        :kernel                 => 'Linux'
       }
     end
 
@@ -752,9 +808,10 @@ describe 'ntp' do
 
   context 'on Linux Xen guest' do
     let :facts do
-      { :osfamily => 'RedHat',
-        :virtual  => 'xenu',
-        :kernel   => 'Linux'
+      { :osfamily               => 'RedHat',
+        :operatingsystemrelease =>  '6',
+        :virtual                => 'xenu',
+        :kernel                 => 'Linux'
       }
     end
 
@@ -774,7 +831,12 @@ describe 'ntp' do
   end
 
   describe 'with package_name set' do
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     context 'to an array' do
       let(:params) { { :package_name => ['ntp','ntphelper'] } }
@@ -820,7 +882,12 @@ describe 'ntp' do
   end
 
   describe 'with restrict_options set' do
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     context 'to valid \'default kod notrap\'' do
       let(:params) { { :restrict_options => 'default kod notrap' } }
@@ -849,7 +916,12 @@ describe 'ntp' do
   end
 
   describe 'with restrict_localhost set' do
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+      }
+    end
 
     context 'to valid [ \'10.0.0.0\', \'127.0.0.2\', ]' do
       let(:params) { { :restrict_localhost => [ '10.0.0.0', '127.0.0.2', ] } }
@@ -878,7 +950,11 @@ describe 'ntp' do
   end
 
   describe 'with servers set' do
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let(:facts) {
+      {:osfamily                => 'RedHat',
+       :operatingsystemrelease  => '6.0'
+      }
+    }
 
     context 'to valid [ \'ntp1.example.com\', \'ntp2.example.com\', ]' do
       let(:params) { { :servers => [ 'ntp1.example.com', 'ntp2.example.com', ] } }
@@ -907,7 +983,12 @@ describe 'ntp' do
   end
 
   describe 'with disable_monitor set' do
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     [true,'true',false,'false'].each do |value|
       context "to #{value} as #{value.class}" do
@@ -937,7 +1018,12 @@ describe 'ntp' do
   end
 
   describe 'with enable_tinker set to' do
-    let(:facts) { { :osfamily => 'RedHat' } }
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+      }
+    end
 
     [true,'true',false,'false'].each do |value|
       context "valid #{value} as #{value.class}" do
@@ -964,5 +1050,124 @@ describe 'ntp' do
       end
     end
   end
+
+  platforms = {
+    'debian' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'Debian',
+        :sysconffixture         => 'sysconfig.debian',
+        :sysconfig_options      => '-g -x'
+      },
+    'rhel5' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5.0',
+        :sysconffixture         => 'sysconfig.rhel5',
+        :sysconfig_options      => '-u ntp:ntp -p /var/run/ntpd.pid -x'
+      },
+    'rhel6' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.0',
+        :sysconffixture         => 'sysconfig.rhel6',
+        :sysconfig_options      => '-u ntp:ntp -p /var/run/ntpd.pid -g -x'
+      },
+    'rhel7' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '7.0',
+        :sysconffixture         => 'sysconfig.rhel7',
+        :sysconfig_options      => '-g -x'
+      },
+    'suse9' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'Suse',
+        :operatingsystemrelease => '9.0',
+        :sysconffixture         => 'sysconfig.suse9',
+        :sysconfig_options      => ''
+      },
+    'suse10' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'Suse',
+        :operatingsystemrelease => '10.0',
+        :sysconffixture         => 'sysconfig.suse10',
+        :sysconfig_options      => '-u ntp -x'
+      },
+    'suse11.0' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'Suse',
+        :operatingsystemrelease => '11.0',
+        :sysconffixture         => 'sysconfig.suse11.0',
+        :sysconfig_options      => '-g -u ntp:ntp -x'
+      },
+    'suse11.1' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'Suse',
+        :operatingsystemrelease => '11.1',
+        :sysconffixture         => 'sysconfig.suse11.1',
+        :sysconfig_options      => '-g -u ntp:ntp -x'
+      },
+    'suse11.2' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'Suse',
+        :operatingsystemrelease => '11.2',
+        :sysconffixture         => 'sysconfig.suse11.2',
+        :sysconfig_options      => '-g -u ntp:ntp -x'
+      },
+    'suse11.3' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'Suse',
+        :operatingsystemrelease => '11.3',
+        :sysconffixture         => 'sysconfig.suse11.3',
+        :sysconfig_options      => '-g -u ntp:ntp -x'
+      },
+    'suse12' =>
+      { :kernel                 => 'Linux',
+        :osfamily               => 'Suse',
+        :operatingsystemrelease => '12.0',
+        :sysconffixture         => 'sysconfig.suse12',
+        :sysconfig_options      => '-g -u ntp:ntp -x'
+      },
+  }
+
+  describe 'sysconfig file with default values for parameters on' do
+    platforms.sort.each do |k,v|
+      context "#{k}" do
+        let :facts do
+          { :kernel                   => v[:kernel],
+            :osfamily                 => v[:osfamily],
+            :operatingsystemrelease   => v[:operatingsystemrelease],
+          }
+        end
+
+        sysconfig_fixture = File.read(fixtures("#{v[:sysconffixture]}"))
+        it {
+          should contain_file('ntp_sysconfig').with_content(sysconfig_fixture)
+        }
+      end
+    end
+  end
+  describe 'sysconfig file with non-default values for parameters on' do
+    platforms.sort.each do |k,v|
+      context "#{k}" do
+        let :facts do
+          { :kernel                   => v[:kernel],
+            :osfamily                 => v[:osfamily],
+            :operatingsystemrelease   => v[:operatingsystemrelease],
+          }
+        end
+        let :params do
+          { :sysconfig_options        => v[:sysconfig_options],
+          }
+        end
+
+        sysconfig_fixture = File.read(fixtures("#{v[:sysconffixture]}"))
+        it {
+          should contain_file('ntp_sysconfig').with_content(/#{v[:sysconfig_options]}/)
+        }
+      end
+    end
+  end
+
 
 end

--- a/spec/fixtures/sysconfig.debian
+++ b/spec/fixtures/sysconfig.debian
@@ -1,0 +1,4 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTS='-g'

--- a/spec/fixtures/sysconfig.rhel5
+++ b/spec/fixtures/sysconfig.rhel5
@@ -1,0 +1,11 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+# Drop root to id 'ntp:ntp' by default.
+OPTIONS="-u ntp:ntp -p /var/run/ntpd.pid"
+
+# Set to 'yes' to sync hw clock after successful ntpdate
+SYNC_HWCLOCK=no
+
+# Additional options for ntpdate
+NTPDATE_OPTIONS=""

--- a/spec/fixtures/sysconfig.rhel6
+++ b/spec/fixtures/sysconfig.rhel6
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+# Drop root to id 'ntp:ntp' by default.
+OPTIONS="-u ntp:ntp -p /var/run/ntpd.pid -g"

--- a/spec/fixtures/sysconfig.rhel7
+++ b/spec/fixtures/sysconfig.rhel7
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+# Command line options for ntpd
+OPTIONS="-g"

--- a/spec/fixtures/sysconfig.suse10
+++ b/spec/fixtures/sysconfig.suse10
@@ -1,0 +1,18 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_INITIAL_NTPDATE=" "
+
+NTPD_ADJUST_CMOS_CLOCK="no"
+
+NTPD_OPTIONS="-u ntp"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_START="yes"

--- a/spec/fixtures/sysconfig.suse11.0
+++ b/spec/fixtures/sysconfig.suse11.0
@@ -1,0 +1,12 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""

--- a/spec/fixtures/sysconfig.suse11.1
+++ b/spec/fixtures/sysconfig.suse11.1
@@ -1,0 +1,16 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_FORCE_SYNC_ON_STARTUP="no"
+
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="no"

--- a/spec/fixtures/sysconfig.suse11.2
+++ b/spec/fixtures/sysconfig.suse11.2
@@ -1,0 +1,14 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_FORCE_SYNC_ON_STARTUP="no"

--- a/spec/fixtures/sysconfig.suse11.3
+++ b/spec/fixtures/sysconfig.suse11.3
@@ -1,0 +1,14 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_FORCE_SYNC_ON_STARTUP="no"

--- a/spec/fixtures/sysconfig.suse12
+++ b/spec/fixtures/sysconfig.suse12
@@ -1,0 +1,16 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp"
+
+NTPD_RUN_CHROOTED="no"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_FORCE_SYNC_ON_STARTUP="no"
+
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="yes"

--- a/spec/fixtures/sysconfig.suse9
+++ b/spec/fixtures/sysconfig.suse9
@@ -1,0 +1,2 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT

--- a/templates/sysconfig.debian.erb
+++ b/templates/sysconfig.debian.erb
@@ -1,0 +1,4 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTS='<%= @sysconfig_options_real %>'

--- a/templates/sysconfig.rhel5.erb
+++ b/templates/sysconfig.rhel5.erb
@@ -1,0 +1,11 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+# Drop root to id 'ntp:ntp' by default.
+OPTIONS="<%= @sysconfig_options_real %>"
+
+# Set to 'yes' to sync hw clock after successful ntpdate
+SYNC_HWCLOCK=no
+
+# Additional options for ntpdate
+NTPDATE_OPTIONS=""

--- a/templates/sysconfig.rhel6.erb
+++ b/templates/sysconfig.rhel6.erb
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+# Drop root to id 'ntp:ntp' by default.
+OPTIONS="<%= @sysconfig_options_real %>"

--- a/templates/sysconfig.rhel7.erb
+++ b/templates/sysconfig.rhel7.erb
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+# Command line options for ntpd
+OPTIONS="<%= @sysconfig_options_real %>"

--- a/templates/sysconfig.suse10.erb
+++ b/templates/sysconfig.suse10.erb
@@ -1,0 +1,18 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_INITIAL_NTPDATE=" "
+
+NTPD_ADJUST_CMOS_CLOCK="no"
+
+NTPD_OPTIONS="<%= @sysconfig_options_real %>"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_START="yes"

--- a/templates/sysconfig.suse11.erb
+++ b/templates/sysconfig.suse11.erb
@@ -1,0 +1,18 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="<%= @sysconfig_options_real %>"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+<% if @operatingsystemrelease != '11.0' %>
+NTPD_FORCE_SYNC_ON_STARTUP="no"
+<% end -%>
+<% if @operatingsystemrelease == '11.1' %>
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="no"
+<% end -%>

--- a/templates/sysconfig.suse12.erb
+++ b/templates/sysconfig.suse12.erb
@@ -1,0 +1,16 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="<%= @sysconfig_options_real %>"
+
+NTPD_RUN_CHROOTED="no"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_FORCE_SYNC_ON_STARTUP="no"
+
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="yes"

--- a/templates/sysconfig.suse9.erb
+++ b/templates/sysconfig.suse9.erb
@@ -1,0 +1,2 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT


### PR DESCRIPTION
Adds support to manage ntp's sysconfig file. It has been tested on all affected operating system families and versions. It does not seem like a sysconfig file is used for SLE9 and hence it's empty (except for the header).

My modifications required that *lsbmajdistrelease* was added to quite a few spec tests.