### PR TITLE
Statistics were still created on some OS

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -467,7 +467,7 @@ describe 'ntp' do
       context "specified as #{value}" do
         let(:params) { { :enable_stats => value } }
 
-        it { should contain_file('ntp_conf').with_content(/^statsdir \/var\/log\/ntpstats\/$/) }
+        it { should contain_file('ntp_conf').with_content(/^statsdir \/var\/log\/ntpstats\/.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
       end
     end
 
@@ -475,7 +475,7 @@ describe 'ntp' do
       context "specified as #{value}" do
         let(:params) { { :enable_stats => value } }
 
-        it { should_not contain_file('ntp_conf').with_content(/^\s*statsdir/) }
+        it { should_not contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
       end
     end
 
@@ -502,7 +502,7 @@ describe 'ntp' do
           }
         end
 
-        it { should contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir$/) }
+        it { should contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
       end
 
       context 'with enable_stats as false' do
@@ -514,7 +514,7 @@ describe 'ntp' do
           }
         end
 
-        it { should_not contain_file('ntp_conf').with_content(/^\s*statsdir/) }
+        it { should_not contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
       end
     end
 

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -14,16 +14,15 @@ driftfile <%= @driftfile_real %>
 <% if @my_enable_stats == true %>
 # Statistics are being logged
 statsdir <%= @statsdir %>
+statistics loopstats peerstats clockstats
+filegen loopstats file loopstats type day enable
+filegen peerstats file peerstats type day enable
+filegen clockstats file clockstats type day enable
 <% else %>
 # Statistics are not being logged
 <% end %>
 
 <% if @logfile != 'UNSET' %>logfile <%= @logfile %><% end %>
-
-statistics loopstats peerstats clockstats
-filegen loopstats file loopstats type day enable
-filegen peerstats file peerstats type day enable
-filegen clockstats file clockstats type day enable
 
 # You do need to talk to an NTP server or two (or three).
 #server ntp.your-provider.example


### PR DESCRIPTION
statsdir has a default value on some os and therefore statistics were still activated even though my_enable_stat was set to 'false'.