### PR TITLE
Statistics were still created on some OS

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -451,7 +451,7 @@ describe 'ntp' do
       context "specified as #{value}" do
         let(:params) { { :enable_stats => value } }
 
-        it { should contain_file('ntp_conf').with_content(/^statsdir \/var\/log\/ntpstats\/.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
+        it { should contain_file('ntp_conf').with_content(/^statsdir \/var\/log\/ntpstats\/\nstatistics loopstats peerstats clockstats\nfilegen loopstats file loopstats type day enable\nfilegen peerstats file peerstats type day enable\nfilegen clockstats file clockstats type day enable$/) }
       end
     end
 
@@ -459,7 +459,7 @@ describe 'ntp' do
       context "specified as #{value}" do
         let(:params) { { :enable_stats => value } }
 
-        it { should_not contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
+        it { should contain_file('ntp_conf').without_content(/^statsdir \/var\/log\/ntpstats\/\nstatistics loopstats peerstats clockstats\nfilegen loopstats file loopstats type day enable\nfilegen peerstats file peerstats type day enable\nfilegen clockstats file clockstats type day enable$/) }
       end
     end
 
@@ -486,7 +486,7 @@ describe 'ntp' do
           }
         end
 
-        it { should contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
+        it { should contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir\nstatistics loopstats peerstats clockstats\nfilegen loopstats file loopstats type day enable\nfilegen peerstats file peerstats type day enable\nfilegen clockstats file clockstats type day enable$/) }
       end
 
       context 'with enable_stats as false' do
@@ -498,7 +498,7 @@ describe 'ntp' do
           }
         end
 
-        it { should_not contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
+        it { should contain_file('ntp_conf').without_content(/^statsdir \/path\/to\/statsdir\/\nstatistics loopstats peerstats clockstats\nfilegen loopstats file loopstats type day enable\nfilegen peerstats file peerstats type day enable\nfilegen clockstats file clockstats type day enable$/) }
       end
     end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -451,7 +451,7 @@ describe 'ntp' do
       context "specified as #{value}" do
         let(:params) { { :enable_stats => value } }
 
-        it { should contain_file('ntp_conf').with_content(/^statsdir \/var\/log\/ntpstats\/$/) }
+        it { should contain_file('ntp_conf').with_content(/^statsdir \/var\/log\/ntpstats\/.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
       end
     end
 
@@ -459,7 +459,7 @@ describe 'ntp' do
       context "specified as #{value}" do
         let(:params) { { :enable_stats => value } }
 
-        it { should_not contain_file('ntp_conf').with_content(/^\s*statsdir/) }
+        it { should_not contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
       end
     end
 
@@ -486,7 +486,7 @@ describe 'ntp' do
           }
         end
 
-        it { should contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir$/) }
+        it { should contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
       end
 
       context 'with enable_stats as false' do
@@ -498,7 +498,7 @@ describe 'ntp' do
           }
         end
 
-        it { should_not contain_file('ntp_conf').with_content(/^\s*statsdir/) }
+        it { should_not contain_file('ntp_conf').with_content(/^statsdir \/path\/to\/statsdir.statistics loopstats peerstats clockstats.filegen loopstats file loopstats type day enable.filegen peerstats file peerstats type day enable.filegen clockstats file clockstats type day enable$/m) }
       end
     end
 

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -14,16 +14,15 @@ driftfile <%= @driftfile_real %>
 <% if @my_enable_stats == true %>
 # Statistics are being logged
 statsdir <%= @statsdir %>
+statistics loopstats peerstats clockstats
+filegen loopstats file loopstats type day enable
+filegen peerstats file peerstats type day enable
+filegen clockstats file clockstats type day enable
 <% else %>
 # Statistics are not being logged
 <% end %>
 
 <% if @logfile != 'UNSET' %>logfile <%= @logfile %><% end %>
-
-statistics loopstats peerstats clockstats
-filegen loopstats file loopstats type day enable
-filegen peerstats file peerstats type day enable
-filegen clockstats file clockstats type day enable
 
 # You do need to talk to an NTP server or two (or three).
 #server ntp.your-provider.example


### PR DESCRIPTION
I am taking over ejabach's PR https://github.com/ghoneycutt/puppet-module-ntp/pull/82.

Regex was slight changed for easier readability.

Also changed
`should_not contain_file('ntp_conf').with_content`
to
`should contain_file('ntp_conf').without_content`