### PR TITLE
disable monitor by default to address CVE-2013-5211

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,7 +37,7 @@ class ntp (
   $statsdir            = '/var/log/ntpstats/',
   $logfile             = 'UNSET',
   $ignore_local_clock  = false,
-  $disable_monitor     = false,
+  $disable_monitor     = true,
   $sysconfig_path      = 'USE_DEFAULTS',
   $sysconfig_options   = 'USE_DEFAULTS',
 ) {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -341,6 +341,7 @@ describe 'ntp' do
         end
         it { should contain_file('ntp_conf').with_content(/# Statistics are not being logged$/) }
         it { should contain_file('ntp_conf').with_content(/server 0.us.pool.ntp.org\nserver 1.us.pool.ntp.org\nserver 2.us.pool.ntp.org/) }
+        it { should contain_file('ntp_conf').with_content(/^disable monitor$/) }
         it { should contain_file('ntp_conf').without_content(/^\s*peer/) }
         if v[:keys] != ''
           it { should contain_file('ntp_conf').with_content(/^keys #{Regexp.escape(v[:keys])}$/) }
@@ -1002,7 +1003,6 @@ describe 'ntp' do
         else
           it { should contain_file('ntp_conf').without_content(/^disable monitor$/) }
         end
-
       end
     end
 


### PR DESCRIPTION
Without 'disable monitor' in ntp.conf, the ntp server is vulnerable to
being used for amplification attacks.