### PR TITLE
Enable force sync

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ end
 
 gem 'metadata-json-lint'
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
-gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet'
+gem 'puppet-lint', :git => 'https://github.com/rodjek/puppet-lint.git'
 gem 'puppet-lint-absolute_classname-check'
 gem 'puppet-lint-alias-check'
 gem 'puppet-lint-empty_string-check'
@@ -24,7 +24,9 @@ gem 'puppet-lint-undef_in_function-check'
 gem 'puppet-lint-unquoted_string-check'
 gem 'puppet-lint-variable_contains_upcase'
 
-# rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  # rspec must be v2 for ruby 1.8.7
   gem 'rspec', '~> 2.0'
+  # rake >= 11 does not support ruby 1.8.7
+  gem 'rake', '~> 10.0'
 end

--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ String with startup options to pass to ntp.
 
 - *Default*: 'USE_DEFAULTS'
 
+sysconfig_force_sync_on_startup
+-----------------
+Set NTPD_FORCE_SYNC_ON_STARTUP on SLES11 and SLES12. Valid values are 'yes' and 'no'.
+
+- *Default*: 'UNSET'
+
+sysconfig_force_sync_hwclock_on_startup
+-----------------
+Set NTPD_FORCE_SYNC_HWCLACK_ON_STARTUP on SLES11 and SLES12. Valid values are 'yes' and 'no'.
+
+- *Default*: 'UNSET'
+
 step_tickers_ensure
 -------------------
 Ensure step tickers file. Valid values are 'present' and 'absent'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -252,9 +252,11 @@ class ntp (
       $default_driftfile           = '/var/ntp/ntp.drift'
       $default_keys                = '/etc/inet/ntp.keys'
       $default_enable_tinker       = false
+      $default_sysconfig_path      = undef
+      $default_sysconfig_options   = undef
     }
     default: {
-      fail("The ntp module is supported by OS Families Debian, RedHat, Suse, and Solaris. Your operatingsystem, ${::operatingsystem}, is part of the osfamily, ${::osfamily}")
+      fail("The ntp module is supported by OS Families Debian, RedHat, Suse, and Solaris. Your are running ${::osfamily}")
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,43 +3,45 @@
 # This module manages the ntp service.
 #
 class ntp (
-  $config_file_owner   = 'root',
-  $config_file_group   = 'root',
-  $config_file_mode    = '0644',
-  $package_latest      = false,
-  $package_name        = 'USE_DEFAULTS',
-  $package_noop        = 'USE_DEFAULTS',
-  $package_source      = 'USE_DEFAULTS',
-  $package_adminfile   = 'USE_DEFAULTS',
-  $service_name        = 'USE_DEFAULTS',
-  $config_file         = 'USE_DEFAULTS',
-  $driftfile           = 'USE_DEFAULTS',
-  $service_running     = true,
-  $service_hasstatus   = true,
-  $service_hasrestart  = true,
-  $keys                = 'USE_DEFAULTS',
-  $servers             = ['0.us.pool.ntp.org',
-                          '1.us.pool.ntp.org',
-                          '2.us.pool.ntp.org'],
-  $server_options      = 'UNSET',
-  $peers               = 'UNSET',
-  $restrict_options    = 'USE_DEFAULTS',
-  $restrict_localhost  = 'USE_DEFAULTS',
-  $step_tickers_ensure = 'USE_DEFAULTS',
-  $step_tickers_path   = '/etc/ntp/step-tickers',
-  $step_tickers_owner  = 'root',
-  $step_tickers_group  = 'root',
-  $step_tickers_mode   = '0644',
-  $orphan_mode_stratum = 'UNSET',
-  $fudge_stratum       = '10',
-  $enable_stats        = false,
-  $enable_tinker       = 'USE_DEFAULTS',
-  $statsdir            = '/var/log/ntpstats/',
-  $logfile             = 'UNSET',
-  $ignore_local_clock  = false,
-  $disable_monitor     = true,
-  $sysconfig_path      = 'USE_DEFAULTS',
-  $sysconfig_options   = 'USE_DEFAULTS',
+  $config_file_owner                       = 'root',
+  $config_file_group                       = 'root',
+  $config_file_mode                        = '0644',
+  $package_latest                          = false,
+  $package_name                            = 'USE_DEFAULTS',
+  $package_noop                            = 'USE_DEFAULTS',
+  $package_source                          = 'USE_DEFAULTS',
+  $package_adminfile                       = 'USE_DEFAULTS',
+  $service_name                            = 'USE_DEFAULTS',
+  $config_file                             = 'USE_DEFAULTS',
+  $driftfile                               = 'USE_DEFAULTS',
+  $service_running                         = true,
+  $service_hasstatus                       = true,
+  $service_hasrestart                      = true,
+  $keys                                    = 'USE_DEFAULTS',
+  $servers                                 = ['0.us.pool.ntp.org',
+                                              '1.us.pool.ntp.org',
+                                              '2.us.pool.ntp.org'],
+  $server_options                          = 'UNSET',
+  $peers                                   = 'UNSET',
+  $restrict_options                        = 'USE_DEFAULTS',
+  $restrict_localhost                      = 'USE_DEFAULTS',
+  $step_tickers_ensure                     = 'USE_DEFAULTS',
+  $step_tickers_path                       = '/etc/ntp/step-tickers',
+  $step_tickers_owner                      = 'root',
+  $step_tickers_group                      = 'root',
+  $step_tickers_mode                       = '0644',
+  $orphan_mode_stratum                     = 'UNSET',
+  $fudge_stratum                           = '10',
+  $enable_stats                            = false,
+  $enable_tinker                           = 'USE_DEFAULTS',
+  $statsdir                                = '/var/log/ntpstats/',
+  $logfile                                 = 'UNSET',
+  $ignore_local_clock                      = false,
+  $disable_monitor                         = true,
+  $sysconfig_path                          = 'USE_DEFAULTS',
+  $sysconfig_options                       = 'USE_DEFAULTS',
+  $sysconfig_force_sync_on_startup         = 'USE_DEFAULTS',
+  $sysconfig_force_sync_hwclock_on_startup = 'USE_DEFAULTS',
 ) {
 
   # validate type as array or fail
@@ -144,6 +146,8 @@ class ntp (
       $default_sysconfig_path      = '/etc/default/ntp'
       $sysconfig_erb               = 'sysconfig.debian.erb'
       $default_sysconfig_options   = '-g'
+      $default_sysconfig_force_sync_on_startup = undef
+      $default_sysconfig_force_sync_hwclock_on_startup = undef
     }
     'RedHat': {
       $default_package_name        = [ 'ntp' ]
@@ -158,6 +162,8 @@ class ntp (
       $default_keys                = '/etc/ntp/keys'
       $default_enable_tinker       = true
       $default_sysconfig_path      = '/etc/sysconfig/ntpd'
+      $default_sysconfig_force_sync_on_startup = undef
+      $default_sysconfig_force_sync_hwclock_on_startup = undef
       case $::operatingsystemrelease {
         /^5/: {
           $default_driftfile           = '/var/lib/ntp/ntp.drift'
@@ -198,23 +204,31 @@ class ntp (
           $default_package_name       = [ 'xntp' ]
           $default_service_name       = 'ntp'
           $default_sysconfig_options  = '-u ntp'
+          $default_sysconfig_force_sync_on_startup = undef
+          $default_sysconfig_force_sync_hwclock_on_startup = undef
           $sysconfig_erb              = 'sysconfig.suse9.erb'
         }
         /^10/: {
           $default_package_name       = [ 'xntp' ]
           $default_service_name       = 'ntp'
           $default_sysconfig_options  = '-u ntp'
+          $default_sysconfig_force_sync_on_startup = undef
+          $default_sysconfig_force_sync_hwclock_on_startup = undef
           $sysconfig_erb              = 'sysconfig.suse10.erb'
         }
         /^11/: {
           $default_package_name       = [ 'ntp' ]
           $default_service_name       = 'ntp'
           $default_sysconfig_options  = '-g -u ntp:ntp'
+          $default_sysconfig_force_sync_on_startup = 'no'
+          $default_sysconfig_force_sync_hwclock_on_startup = 'no'
           $sysconfig_erb              = 'sysconfig.suse11.erb'
         }
         /^12/: {
           $default_package_name       = [ 'ntp' ]
           $default_sysconfig_options  = '-g -u ntp:ntp'
+          $default_sysconfig_force_sync_on_startup = 'no'
+          $default_sysconfig_force_sync_hwclock_on_startup = 'yes'
           $sysconfig_erb              = 'sysconfig.suse12.erb'
           if $::operatingsystem == 'OpenSuSE' {
             $default_service_name = 'ntp'
@@ -252,6 +266,8 @@ class ntp (
       $default_driftfile           = '/var/ntp/ntp.drift'
       $default_keys                = '/etc/inet/ntp.keys'
       $default_enable_tinker       = false
+      $default_sysconfig_force_sync_on_startup = undef
+      $default_sysconfig_force_sync_hwclock_on_startup = undef
       $default_sysconfig_path      = undef
       $default_sysconfig_options   = undef
     }
@@ -375,6 +391,18 @@ class ntp (
     $sysconfig_options_real = $default_sysconfig_options
   } else {
     $sysconfig_options_real = $sysconfig_options
+  }
+
+  if $sysconfig_force_sync_on_startup == 'USE_DEFAULTS' {
+    $sysconfig_force_sync_on_startup_real = $default_sysconfig_force_sync_on_startup
+  } else {
+    $sysconfig_force_sync_on_startup_real = $sysconfig_force_sync_on_startup
+  }
+
+  if $sysconfig_force_sync_hwclock_on_startup == 'USE_DEFAULTS' {
+    $sysconfig_force_sync_hwclock_on_startup_real = $default_sysconfig_force_sync_hwclock_on_startup
+  } else {
+    $sysconfig_force_sync_hwclock_on_startup_real = $sysconfig_force_sync_hwclock_on_startup
   }
 
   if ($package_adminfile_real != '') and ($package_adminfile_real != undef) {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -441,6 +441,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :kernel                 => 'Linux',
+        :virtual                => 'physical',
       }
     end
 
@@ -474,6 +476,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :kernel                 => 'Linux',
+        :virtual                => 'physical',
       }
     end
 
@@ -498,6 +502,8 @@ describe 'ntp' do
         {
           :osfamily               => 'RedHat',
           :operatingsystemrelease => '6.0',
+          :kernel                 => 'Linux',
+          :virtual                => 'physical',
         }
       end
       let(:params) { { :enable_stats => ['not','a','boolean'] } }
@@ -515,6 +521,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :kernel                 => 'Linux',
+        :virtual                => 'physical',
       }
     end
 
@@ -559,6 +567,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :kernel                 => 'Linux',
+        :virtual                => 'physical',
       }
     end
 
@@ -592,6 +602,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :kernel                 => 'Linux',
+        :virtual                => 'physical',
       }
     end
 
@@ -638,6 +650,8 @@ describe 'ntp' do
         {
           :osfamily      => 'Solaris',
           :kernelrelease => '5.11',
+          :kernel        => 'SunOS',
+          :virtual       => 'physical',
         }
       end
 
@@ -660,6 +674,8 @@ describe 'ntp' do
         {
           :osfamily      => 'Solaris',
           :kernelrelease => '5.11',
+          :kernel        => 'SunOS',
+          :virtual       => 'physical',
         }
       end
 
@@ -686,7 +702,10 @@ describe 'ntp' do
 
   context 'on unsupported SuSE platform should fail' do
     let :facts do
-      { :osfamily => 'Suse' }
+      {
+        :osfamily => 'Suse',
+        :operatingsystemrelease => '0',
+      }
     end
 
     it do
@@ -698,7 +717,11 @@ describe 'ntp' do
 
   context 'on unsupported Solaris platform should fail' do
     let :facts do
-      { :osfamily => 'Solaris' }
+      {
+        :osfamily => 'Solaris',
+        :operatingsystemrelease => '0.0',
+        :kernelrelease => '0.0',
+      }
     end
 
     it do
@@ -709,6 +732,11 @@ describe 'ntp' do
   end
 
   context 'on unsupported platform should fail' do
+    let :facts do
+      {
+        :osfamily => 'unsupportedOS',
+      }
+    end
     it do
       expect {
         should contain_class('ntp')
@@ -722,6 +750,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :kernel                 => 'Linux',
+        :virtual                => 'physical',
       }
     end
 
@@ -738,6 +768,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :kernel                 => 'Linux',
+        :virtual                => 'physical',
       }
     end
 
@@ -755,6 +787,8 @@ describe 'ntp' do
         {
           :osfamily               => 'RedHat',
           :operatingsystemrelease => '6.0',
+          :kernel                 => 'Linux',
+          :virtual                => 'physical',
         }
       end
 
@@ -769,6 +803,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :kernel                 => 'Linux',
+        :virtual                => 'physical',
       }
     end
 
@@ -785,6 +821,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :kernel                 => 'Linux',
+        :virtual                => 'physical',
       }
     end
 
@@ -836,6 +874,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :virtual                => 'physical',
+        :kernel                 => 'Linux'
       }
     end
 
@@ -887,6 +927,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :virtual                => 'physical',
+        :kernel                 => 'Linux'
       }
     end
 
@@ -953,7 +995,9 @@ describe 'ntp' do
   describe 'with servers set' do
     let(:facts) {
       {:osfamily                => 'RedHat',
-       :operatingsystemrelease  => '6.0'
+       :operatingsystemrelease  => '6.0',
+       :virtual                => 'physical',
+       :kernel                 => 'Linux'
       }
     }
 
@@ -988,6 +1032,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :virtual                => 'physical',
+        :kernel                 => 'Linux'
       }
     end
 
@@ -1022,6 +1068,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6.0',
+        :virtual                => 'physical',
+        :kernel                 => 'Linux'
       }
     end
 
@@ -1055,12 +1103,14 @@ describe 'ntp' do
     'debian' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'Debian',
+        :operatingsystem        => 'Debian',
         :sysconffixture         => 'sysconfig.debian',
         :sysconfig_options      => '-g -x'
       },
     'rhel5' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'RedHat',
+        :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '5.0',
         :sysconffixture         => 'sysconfig.rhel5',
         :sysconfig_options      => '-u ntp:ntp -p /var/run/ntpd.pid -x'
@@ -1068,6 +1118,7 @@ describe 'ntp' do
     'rhel6' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'RedHat',
+        :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '6.0',
         :sysconffixture         => 'sysconfig.rhel6',
         :sysconfig_options      => '-u ntp:ntp -p /var/run/ntpd.pid -g -x'
@@ -1075,6 +1126,7 @@ describe 'ntp' do
     'rhel7' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'RedHat',
+        :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '7.0',
         :sysconffixture         => 'sysconfig.rhel7',
         :sysconfig_options      => '-g -x'
@@ -1082,6 +1134,7 @@ describe 'ntp' do
     'suse9' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'Suse',
+        :operatingsystem        => 'SLES',
         :operatingsystemrelease => '9.0',
         :sysconffixture         => 'sysconfig.suse9',
         :sysconfig_options      => ''
@@ -1089,6 +1142,7 @@ describe 'ntp' do
     'suse10' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'Suse',
+        :operatingsystem        => 'SLES',
         :operatingsystemrelease => '10.0',
         :sysconffixture         => 'sysconfig.suse10',
         :sysconfig_options      => '-u ntp -x'
@@ -1096,6 +1150,7 @@ describe 'ntp' do
     'suse11.0' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'Suse',
+        :operatingsystem        => 'SLES',
         :operatingsystemrelease => '11.0',
         :sysconffixture         => 'sysconfig.suse11.0',
         :sysconfig_options      => '-g -u ntp:ntp -x'
@@ -1103,6 +1158,7 @@ describe 'ntp' do
     'suse11.1' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'Suse',
+        :operatingsystem        => 'SLES',
         :operatingsystemrelease => '11.1',
         :sysconffixture         => 'sysconfig.suse11.1',
         :sysconfig_options      => '-g -u ntp:ntp -x'
@@ -1110,6 +1166,7 @@ describe 'ntp' do
     'suse11.2' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'Suse',
+        :operatingsystem        => 'SLES',
         :operatingsystemrelease => '11.2',
         :sysconffixture         => 'sysconfig.suse11.2',
         :sysconfig_options      => '-g -u ntp:ntp -x'
@@ -1117,6 +1174,7 @@ describe 'ntp' do
     'suse11.3' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'Suse',
+        :operatingsystem        => 'SLES',
         :operatingsystemrelease => '11.3',
         :sysconffixture         => 'sysconfig.suse11.3',
         :sysconfig_options      => '-g -u ntp:ntp -x'
@@ -1124,6 +1182,7 @@ describe 'ntp' do
     'suse11.4' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'Suse',
+        :operatingsystem        => 'SLES',
         :operatingsystemrelease => '11.4',
         :sysconffixture         => 'sysconfig.suse11.4',
         :sysconfig_options      => '-g -u ntp:ntp -x'
@@ -1131,6 +1190,7 @@ describe 'ntp' do
     'suse12' =>
       { :kernel                 => 'Linux',
         :osfamily               => 'Suse',
+        :operatingsystem        => 'SLES',
         :operatingsystemrelease => '12.0',
         :sysconffixture         => 'sysconfig.suse12',
         :sysconfig_options      => '-g -u ntp:ntp -x'
@@ -1143,7 +1203,9 @@ describe 'ntp' do
         let :facts do
           { :kernel                   => v[:kernel],
             :osfamily                 => v[:osfamily],
+            :operatingsystem          => v[:operatingsystem],
             :operatingsystemrelease   => v[:operatingsystemrelease],
+            :virtual                  => 'physical',
           }
         end
 
@@ -1160,7 +1222,9 @@ describe 'ntp' do
         let :facts do
           { :kernel                   => v[:kernel],
             :osfamily                 => v[:osfamily],
+            :operatingsystem          => v[:operatingsystem],
             :operatingsystemrelease   => v[:operatingsystemrelease],
+            :virtual                  => 'physical',
           }
         end
         let :params do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1103,99 +1103,135 @@ describe 'ntp' do
 
   platforms = {
     'debian' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'Debian',
-        :operatingsystem        => 'Debian',
-        :sysconffixture         => 'sysconfig.debian',
-        :sysconfig_options      => '-g -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'Debian',
+        :operatingsystem                         => 'Debian',
+        :sysconffixture                          => 'sysconfig.debian',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.debian',
+        :sysconfig_options                       => '-g -x',
+        :sysconfig_force_sync_on_startup         => 'UNSET',
+        :sysconfig_force_sync_hwclock_on_startup => 'UNSET'
       },
     'rhel5' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'RedHat',
-        :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '5.0',
-        :sysconffixture         => 'sysconfig.rhel5',
-        :sysconfig_options      => '-u ntp:ntp -p /var/run/ntpd.pid -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'RedHat',
+        :operatingsystem                         => 'RedHat',
+        :operatingsystemrelease                  => '5.0',
+        :sysconffixture                          => 'sysconfig.rhel5',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.rhel5',
+        :sysconfig_options                       => '-u ntp:ntp -p /var/run/ntpd.pid -x',
+        :sysconfig_force_sync_on_startup         => 'UNSET',
+        :sysconfig_force_sync_hwclock_on_startup => 'UNSET'
       },
     'rhel6' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'RedHat',
-        :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '6.0',
-        :sysconffixture         => 'sysconfig.rhel6',
-        :sysconfig_options      => '-u ntp:ntp -p /var/run/ntpd.pid -g -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'RedHat',
+        :operatingsystem                         => 'RedHat',
+        :operatingsystemrelease                  => '6.0',
+        :sysconffixture                          => 'sysconfig.rhel6',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.rhel6',
+        :sysconfig_options                       => '-u ntp:ntp -p /var/run/ntpd.pid -g -x',
+        :sysconfig_force_sync_on_startup         => 'UNSET',
+        :sysconfig_force_sync_hwclock_on_startup => 'UNSET'
       },
     'rhel7' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'RedHat',
-        :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '7.0',
-        :sysconffixture         => 'sysconfig.rhel7',
-        :sysconfig_options      => '-g -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'RedHat',
+        :operatingsystem                         => 'RedHat',
+        :operatingsystemrelease                  => '7.0',
+        :sysconffixture                          => 'sysconfig.rhel7',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.rhel7',
+        :sysconfig_options                       => '-g -x',
+        :sysconfig_force_sync_on_startup         => 'UNSET',
+        :sysconfig_force_sync_hwclock_on_startup => 'UNSET'
       },
     'suse9' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'Suse',
-        :operatingsystem        => 'SLES',
-        :operatingsystemrelease => '9.0',
-        :sysconffixture         => 'sysconfig.suse9',
-        :sysconfig_options      => ''
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'Suse',
+        :operatingsystem                         => 'SLES',
+        :operatingsystemrelease                  => '9.0',
+        :sysconffixture                          => 'sysconfig.suse9',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.suse9',
+        :sysconfig_options                       => '',
+        :sysconfig_force_sync_on_startup         => 'UNSET',
+        :sysconfig_force_sync_hwclock_on_startup => 'UNSET'
       },
     'suse10' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'Suse',
-        :operatingsystem        => 'SLES',
-        :operatingsystemrelease => '10.0',
-        :sysconffixture         => 'sysconfig.suse10',
-        :sysconfig_options      => '-u ntp -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'Suse',
+        :operatingsystem                         => 'SLES',
+        :operatingsystemrelease                  => '10.0',
+        :sysconffixture                          => 'sysconfig.suse10',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.suse10',
+        :sysconfig_options                       => '-u ntp -x',
+        :sysconfig_force_sync_on_startup         => 'UNSET',
+        :sysconfig_force_sync_hwclock_on_startup => 'UNSET'
       },
     'suse11.0' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'Suse',
-        :operatingsystem        => 'SLES',
-        :operatingsystemrelease => '11.0',
-        :sysconffixture         => 'sysconfig.suse11.0',
-        :sysconfig_options      => '-g -u ntp:ntp -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'Suse',
+        :operatingsystem                         => 'SLES',
+        :operatingsystemrelease                  => '11.0',
+        :sysconffixture                          => 'sysconfig.suse11.0',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.suse11.0',
+        :sysconfig_options                       => '-g -u ntp:ntp -x',
+        :sysconfig_force_sync_on_startup         => 'UNSET',
+        :sysconfig_force_sync_hwclock_on_startup => 'UNSET'
       },
     'suse11.1' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'Suse',
-        :operatingsystem        => 'SLES',
-        :operatingsystemrelease => '11.1',
-        :sysconffixture         => 'sysconfig.suse11.1',
-        :sysconfig_options      => '-g -u ntp:ntp -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'Suse',
+        :operatingsystem                         => 'SLES',
+        :operatingsystemrelease                  => '11.1',
+        :sysconffixture                          => 'sysconfig.suse11.1',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.suse11.1',
+        :sysconfig_options                       => '-g -u ntp:ntp -x',
+        :sysconfig_force_sync_on_startup         => 'yes',
+        :sysconfig_force_sync_hwclock_on_startup => 'yes'
       },
     'suse11.2' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'Suse',
-        :operatingsystem        => 'SLES',
-        :operatingsystemrelease => '11.2',
-        :sysconffixture         => 'sysconfig.suse11.2',
-        :sysconfig_options      => '-g -u ntp:ntp -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'Suse',
+        :operatingsystem                         => 'SLES',
+        :operatingsystemrelease                  => '11.2',
+        :sysconffixture                          => 'sysconfig.suse11.2',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.suse11.2',
+        :sysconfig_options                       => '-g -u ntp:ntp -x',
+        :sysconfig_force_sync_on_startup         => 'yes',
+        :sysconfig_force_sync_hwclock_on_startup => 'yes'
       },
     'suse11.3' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'Suse',
-        :operatingsystem        => 'SLES',
-        :operatingsystemrelease => '11.3',
-        :sysconffixture         => 'sysconfig.suse11.3',
-        :sysconfig_options      => '-g -u ntp:ntp -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'Suse',
+        :operatingsystem                         => 'SLES',
+        :operatingsystemrelease                  => '11.3',
+        :sysconffixture                          => 'sysconfig.suse11.3',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.suse11.3',
+        :sysconfig_options                       => '-g -u ntp:ntp -x',
+        :sysconfig_force_sync_on_startup         => 'yes',
+        :sysconfig_force_sync_hwclock_on_startup => 'yes'
       },
     'suse11.4' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'Suse',
-        :operatingsystem        => 'SLES',
-        :operatingsystemrelease => '11.4',
-        :sysconffixture         => 'sysconfig.suse11.4',
-        :sysconfig_options      => '-g -u ntp:ntp -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'Suse',
+        :operatingsystem                         => 'SLES',
+        :operatingsystemrelease                  => '11.4',
+        :sysconffixture                          => 'sysconfig.suse11.4',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.suse11.4',
+        :sysconfig_options                       => '-g -u ntp:ntp -x',
+        :sysconfig_force_sync_on_startup         => 'yes',
+        :sysconfig_force_sync_hwclock_on_startup => 'yes'
       },
     'suse12' =>
-      { :kernel                 => 'Linux',
-        :osfamily               => 'Suse',
-        :operatingsystem        => 'SLES',
-        :operatingsystemrelease => '12.0',
-        :sysconffixture         => 'sysconfig.suse12',
-        :sysconfig_options      => '-g -u ntp:ntp -x'
+      { :kernel                                  => 'Linux',
+        :osfamily                                => 'Suse',
+        :operatingsystem                         => 'SLES',
+        :operatingsystemrelease                  => '12.0',
+        :sysconffixture                          => 'sysconfig.suse12',
+        :sysconfnondefaultfixture                => 'sysconfig.nondefault.suse12',
+        :sysconfig_options                       => '-g -u ntp:ntp -x',
+        :sysconfig_force_sync_on_startup         => 'yes',
+        :sysconfig_force_sync_hwclock_on_startup => 'no'
       },
   }
 
@@ -1231,12 +1267,14 @@ describe 'ntp' do
         end
         let :params do
           { :sysconfig_options        => v[:sysconfig_options],
+            :sysconfig_force_sync_on_startup         => v[:sysconfig_force_sync_on_startup],
+            :sysconfig_force_sync_hwclock_on_startup => v[:sysconfig_force_sync_hwclock_on_startup],
           }
         end
 
-        sysconfig_fixture = File.read(fixtures("#{v[:sysconffixture]}"))
+        sysconfig_nondefault_fixture  = File.read(fixtures("#{v[:sysconfnondefaultfixture]}"))
         it {
-          should contain_file('ntp_sysconfig').with_content(/#{v[:sysconfig_options]}/)
+          should contain_file('ntp_sysconfig').with_content(sysconfig_nondefault_fixture)
         }
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -963,6 +963,8 @@ describe 'ntp' do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6',
+        :virtual                => 'physical',
+        :kernel                 => 'Linux'
       }
     end
 

--- a/spec/fixtures/sysconfig.nondefault.debian
+++ b/spec/fixtures/sysconfig.nondefault.debian
@@ -1,0 +1,4 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTS='-g -x'

--- a/spec/fixtures/sysconfig.nondefault.rhel5
+++ b/spec/fixtures/sysconfig.nondefault.rhel5
@@ -1,0 +1,11 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+# Drop root to id 'ntp:ntp' by default.
+OPTIONS="-u ntp:ntp -p /var/run/ntpd.pid -x"
+
+# Set to 'yes' to sync hw clock after successful ntpdate
+SYNC_HWCLOCK=no
+
+# Additional options for ntpdate
+NTPDATE_OPTIONS=""

--- a/spec/fixtures/sysconfig.nondefault.rhel6
+++ b/spec/fixtures/sysconfig.nondefault.rhel6
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+# Drop root to id 'ntp:ntp' by default.
+OPTIONS="-u ntp:ntp -p /var/run/ntpd.pid -g -x"

--- a/spec/fixtures/sysconfig.nondefault.rhel7
+++ b/spec/fixtures/sysconfig.nondefault.rhel7
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+# Command line options for ntpd
+OPTIONS="-g -x"

--- a/spec/fixtures/sysconfig.nondefault.suse10
+++ b/spec/fixtures/sysconfig.nondefault.suse10
@@ -1,0 +1,18 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_INITIAL_NTPDATE=" "
+
+NTPD_ADJUST_CMOS_CLOCK="no"
+
+NTPD_OPTIONS="-u ntp -x"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_START="yes"

--- a/spec/fixtures/sysconfig.nondefault.suse11.0
+++ b/spec/fixtures/sysconfig.nondefault.suse11.0
@@ -1,0 +1,12 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp -x"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""

--- a/spec/fixtures/sysconfig.nondefault.suse11.1
+++ b/spec/fixtures/sysconfig.nondefault.suse11.1
@@ -1,0 +1,16 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp -x"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_FORCE_SYNC_ON_STARTUP="yes"
+
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="yes"

--- a/spec/fixtures/sysconfig.nondefault.suse11.2
+++ b/spec/fixtures/sysconfig.nondefault.suse11.2
@@ -1,0 +1,16 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp -x"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_FORCE_SYNC_ON_STARTUP="yes"
+
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="yes"

--- a/spec/fixtures/sysconfig.nondefault.suse11.3
+++ b/spec/fixtures/sysconfig.nondefault.suse11.3
@@ -1,0 +1,16 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp -x"
+
+NTPD_RUN_CHROOTED="yes"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_FORCE_SYNC_ON_STARTUP="yes"
+
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="yes"

--- a/spec/fixtures/sysconfig.nondefault.suse11.4
+++ b/spec/fixtures/sysconfig.nondefault.suse11.4
@@ -1,0 +1,16 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp -x"
+
+NTPD_RUN_CHROOTED="no"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_FORCE_SYNC_ON_STARTUP="yes"
+
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="yes"

--- a/spec/fixtures/sysconfig.nondefault.suse12
+++ b/spec/fixtures/sysconfig.nondefault.suse12
@@ -1,0 +1,16 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+NTPD_OPTIONS="-g -u ntp:ntp -x"
+
+NTPD_RUN_CHROOTED="no"
+
+NTPD_CHROOT_FILES=""
+
+NTP_PARSE_LINK=""
+
+NTP_PARSE_DEVICE=""
+
+NTPD_FORCE_SYNC_ON_STARTUP="yes"
+
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="no"

--- a/spec/fixtures/sysconfig.nondefault.suse9
+++ b/spec/fixtures/sysconfig.nondefault.suse9
@@ -1,0 +1,2 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT

--- a/templates/sysconfig.suse11.erb
+++ b/templates/sysconfig.suse11.erb
@@ -15,7 +15,7 @@ NTP_PARSE_LINK=""
 
 NTP_PARSE_DEVICE=""
 <% if @operatingsystemrelease != '11.0' %>
-NTPD_FORCE_SYNC_ON_STARTUP="no"
+NTPD_FORCE_SYNC_ON_STARTUP="<%= @sysconfig_force_sync_on_startup_real %>"
 
-NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="no"
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="<%= @sysconfig_force_sync_hwclock_on_startup_real %>"
 <% end -%>

--- a/templates/sysconfig.suse12.erb
+++ b/templates/sysconfig.suse12.erb
@@ -11,6 +11,6 @@ NTP_PARSE_LINK=""
 
 NTP_PARSE_DEVICE=""
 
-NTPD_FORCE_SYNC_ON_STARTUP="no"
+NTPD_FORCE_SYNC_ON_STARTUP="<%= @sysconfig_force_sync_on_startup_real %>"
 
-NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="yes"
+NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP="<%= @sysconfig_force_sync_hwclock_on_startup_real %>"


### PR DESCRIPTION
Make it possible to set NTPD_FORCE_SYNC_ON_STARTUP and NTPD_FORCE_SYNC_HWCLOCK_ON_STARTUP
on SLES11 and SLES12 to enable sync at boot